### PR TITLE
remove call of cache.get from _call_with_lock

### DIFF
--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -38,10 +38,6 @@ def memoize(
 
             async def _call_with_lock():
                 async with lock(key + ":lock"):
-                    found = await cache.get(key)
-                    if isinstance(found, CacheItem):
-                        return found.value
-
                     result = await fn(*args, **kwargs)
 
                     await cache.set(


### PR DESCRIPTION
since the cache check is already being made before caliing it, `_call_with_lock` should be responsible only for calling `fn` and setting the result on cache.

By checking the cache again inside `_call_with_lock`, it ignores the `best_before` parameter