### PR TITLE
Check if another task populated the cache while waiting for the lock

### DIFF
--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -38,6 +38,10 @@ def memoize(
 
             async def _call_with_lock():
                 async with lock(key + ":lock"):
+                    found = await cache.get(key)   # did someone populate the cache while I was waiting for the lock?
+                    if isinstance(found, CacheItem) and not found.is_stale:
+                        return found.value
+
                     result = await fn(*args, **kwargs)
 
                     await cache.set(


### PR DESCRIPTION
This PR reverts the last PR (!1) but adds `and not found.is_stale` to the if condition to only use the cached value if it is not stale.