### PR TITLE
Update cachebox to version 4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Framework :: AsyncIO",
 ]
-dependencies = ["redis>=5.0,<6", "cachebox>=4.1,<5", "typing_extensions>=4.4"]
+dependencies = ["redis>=5.0,<6", "cachebox>=4.5,<5", "typing_extensions>=4.4"]
 
 [project.urls]
 Documentation = "https://github.com/ecarrara/yapcache#readme"


### PR DESCRIPTION
This PR updates the cachebox to v4.5.0.

> Now cachebox uses threading.Lock for sync functions, and asyncio.Lock for async functions to avoid [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede). 

https://github.com/awolverp/cachebox/releases/tag/v4.5.0