### PR TITLE
Return cache hit/miss information in @memoize

### DIFF
--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -56,7 +56,7 @@ def memoize(
                 async with lock(key + ":lock"):
                     found = await cache.get(key)   # did someone populate the cache while I was waiting for the lock?
                     if isinstance(found, CacheItem) and not found.is_stale:
-                        return found.value
+                        return MemoizeResult(result=found.value, cache_status=CacheStatus.HIT)
 
                     result = await fn(*args, **kwargs)
 
@@ -67,7 +67,7 @@ def memoize(
                         best_before=best_before(result, *args, **kwargs),
                     )
 
-                    return result
+                    return MemoizeResult(result=result, cache_status=CacheStatus.MISS)
 
             found = await cache.get(key)
             if isinstance(found, CacheItem):
@@ -77,11 +77,13 @@ def memoize(
                     update_tasks[key] = task  # TODO: acho que tem problema
                     task.add_done_callback(lambda _: update_tasks.pop(key))
                     status = CacheStatus.STALE
-                return process_result(MemoizeResult(result=found.value, cache_status=status), *args, **kwargs)
+                return process_result(
+                    MemoizeResult(result=found.value, cache_status=status), *args, **kwargs
+                )
 
             result = await _call_with_lock()
 
-            return process_result(MemoizeResult(result=result, cache_status=CacheStatus.MISS), *args, **kwargs)
+            return process_result(result, *args, **kwargs)
 
         return wrapper
 

--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -76,6 +76,7 @@ def memoize(
                     task = asyncio.create_task(_call_with_lock())
                     update_tasks[key] = task  # TODO: acho que tem problema
                     task.add_done_callback(lambda _: update_tasks.pop(key))
+                    status = CacheStatus.STALE
                 return process_result(MemoizeResult(result=found.value, cache_status=status), *args, **kwargs)
 
             result = await _call_with_lock()

--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from functools import wraps
 from typing import Generic
 
@@ -23,7 +23,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-class CacheStatus(Enum):
+class CacheStatus(StrEnum):
     HIT = "hit"
     MISS = "miss"
     STALE = "stale"

--- a/src/yapcache/__init__.py
+++ b/src/yapcache/__init__.py
@@ -1,5 +1,8 @@
 import asyncio
+from dataclasses import dataclass
+from enum import Enum
 from functools import wraps
+from typing import Generic
 
 from typing_extensions import (
     Any,
@@ -20,12 +23,25 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+class CacheStatus(Enum):
+    HIT = "hit"
+    MISS = "miss"
+    STALE = "stale"
+
+
+@dataclass
+class MemoizeResult(Generic[R]):
+    cache_status: CacheStatus
+    result: R
+
+
 def memoize(
     cache: Cache,
     cache_key: Callable[P, str],
     ttl: float | Callable[Concatenate[R, P], float],
     best_before: Callable[Concatenate[R, P], Optional[float]] = lambda _, *a, **kw: None,
     lock: Callable[[str], DistLock] = lambda *a, **kw: NullLock(),
+    process_result: Callable[[MemoizeResult[R]], R] = lambda r, *a, **kw: r.result,
 ) -> Callable[
     [Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]
 ]:
@@ -55,15 +71,16 @@ def memoize(
 
             found = await cache.get(key)
             if isinstance(found, CacheItem):
+                status = CacheStatus.HIT
                 if found.is_stale and key not in update_tasks:
                     task = asyncio.create_task(_call_with_lock())
                     update_tasks[key] = task  # TODO: acho que tem problema
                     task.add_done_callback(lambda _: update_tasks.pop(key))
-                return found.value
+                return process_result(MemoizeResult(result=found.value, cache_status=status), *args, **kwargs)
 
             result = await _call_with_lock()
 
-            return result
+            return process_result(MemoizeResult(result=result, cache_status=CacheStatus.MISS), *args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
This PR introduces a new MemoizeResult dataclass and updates the @memoize decorator to provide richer information about cache usage. The main changes are:

**Motivation:**

These changes make it easier for consumers of the memoized function to distinguish whether a result was retrieved from cache, freshly computed, or returned as stale data. This is useful for monitoring, debugging, and implementing advanced caching strategies.

**Implementation:**

A new generic dataclass MemoizeResult[R] is introduced, encapsulating the actual result (result: R) and the cache status (cache_status: CacheStatus / HIT, MISS, or STALE).

The @memoize decorator now returns a MemoizeResult instead of just the cached value or function result.

An optional process_result callback parameter is added to allow users to extract or manipulate the result as needed, defaulting to returning just the value.

All code paths in the memoization logic now annotate returned results with the appropriate CacheStatus (HIT, MISS, or STALE).

**Backward Compatibility:**

By default, the decorator continues to return the cached value (not the full MemoizeResult) to avoid breaking existing code, unless the process_result argument is overridden.
