### PR TITLE
add Cache's delete method

### DIFF
--- a/src/yapcache/caches/__init__.py
+++ b/src/yapcache/caches/__init__.py
@@ -27,6 +27,9 @@ class Cache:
     ):
         raise NotImplementedError
 
+    async def delete(self, key: str) -> bool:
+        raise NotImplementedError
+
     async def close(self): ...
 
     def memoize(self, fn: Callable[P, Coroutine[Any, Any, R]], *args, **kwargs):

--- a/src/yapcache/caches/memory.py
+++ b/src/yapcache/caches/memory.py
@@ -32,3 +32,7 @@ class InMemoryCache(Cache):
             value=CacheItem(value=value, best_before=best_before, ttl=ttl),
             ttl=ttl,
         )
+    
+    @override
+    async def delete(self, key: str) -> bool:
+        return bool(self._cache.pop(self._key(key), None))

--- a/src/yapcache/caches/null.py
+++ b/src/yapcache/caches/null.py
@@ -16,3 +16,6 @@ class NullCache(Cache):
         best_before: float | None = None,
     ):
         ... # no-op
+
+    async def delete(self, key: str) -> bool:
+        ... # no-op

--- a/src/yapcache/caches/redis.py
+++ b/src/yapcache/caches/redis.py
@@ -51,3 +51,7 @@ class RedisCache(Cache):
             ),
             px=int(ttl * 1_000) if ttl is not None else None,
         )
+
+    @override
+    async def delete(self, key: str) -> bool:
+        return bool(await self._client.delete(self._key(key)))


### PR DESCRIPTION
✨ Summary

This PR introduces the delete method to all cache backends (BaseCache, MemoryCache, NullCache, and RedisCache) to provide a consistent interface for removing cache entries.

🔧 Changes

Added delete(self, key: str) -> bool to the base Cache class.

Implemented deletion logic for:

MemoryCache — removes the key from the in-memory dictionary.

RedisCache — deletes the key from Redis and returns True if the key existed.

NullCache — added a no-op delete method for interface consistency.